### PR TITLE
call reset() on $mask.click

### DIFF
--- a/jquery.comiseo.daterangepicker.js
+++ b/jquery.comiseo.daterangepicker.js
@@ -460,7 +460,10 @@
 		function bindEvents() {
 			triggerButton.getElement().click(toggle);
 			triggerButton.getElement().keydown(keyPressTriggerOpenOrClose);
-			$mask.click(close);
+			$mask.click(function() {
+				close();
+				reset();
+			});
 			$(window).resize(function() { isOpen ? autoFit() : autoFitNeeded = true; });
 		}
 

--- a/jquery.comiseo.daterangepicker.js
+++ b/jquery.comiseo.daterangepicker.js
@@ -605,6 +605,7 @@
 			case $.ui.keyCode.ESCAPE:
 				killEvent(event);
 				close();
+				reset();
 				return;
 			case $.ui.keyCode.TAB:
 				close();
@@ -640,7 +641,13 @@
 		}
 
 		function toggle() {
-			isOpen ? close() : open();
+			if(isOpen) {
+				close();
+				reset();
+			}
+			else {
+				open();
+			}
 		}
 
 		function getContainer(){


### PR DESCRIPTION
1. select any value in a datepicker
2. open the datepicker again and mark another value, click 'cancel' button
3. open the datepicker again - you will see a value selected in point 1.
4. select another value and click somewhere outside the datepicker
5. open datepicker again - you will see that value from point 4. is marked (getRange will still return value from point 1)

solution: in $mask.click call both close and reset function as it is done for 'cancel' button click handler