### PR TITLE
Consistent bower dependency support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "jquery": "~1.8.3",
     "jquery-ui": "~1.9.0",
-    "momentjs": "~2.3.0"
+    "moment": "~2.3.0"
   }
 }


### PR DESCRIPTION
Change momentjs with moment as dependency entry.
Most packages define momentjs library just as
moment, even moment's integration plugins are
named moment-plugin_name.