### PR TITLE
bootstrap and jquery-ui $.button() conflict fix.

### DIFF
--- a/jquery.comiseo.daterangepicker.js
+++ b/jquery.comiseo.daterangepicker.js
@@ -111,8 +111,16 @@
 				.attr('for', id);
 		}
 
+		function fixButton() {
+			if ($.fn.button.noConflict) {
+				var btn = $.fn.button.noConflict(); // reverts $.fn.button to jqueryui btn
+				$.fn.btn = btn; // assigns bootstrap button functionality to $.fn.btn
+			}
+		}
+		
 		function init() {
 			fixReferences();
+			fixButton();
 			$self = $('<button type="button"></button>')
 				.addClass(classnameContext + '-triggerbutton')
 				.attr({'title': $originalElement.attr('title'), 'tabindex': $originalElement.attr('tabindex'), id: id})


### PR DESCRIPTION
If you load `bootstrap.js` after `jquery-ui.js` the `$.fn.button()` function will point to a bootstrap method instead of a jquery-ui function.

Fix found at https://github.com/twbs/bootstrap/issues/6094#issuecomment-11148540 might want to add `console.warning('bootstrap conflict with jquery-ui $.fn.button.')` to the inner if block, but I like my console clean.